### PR TITLE
Run on Apple Silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2019-latest
+    image: mcr.microsoft.com/azure-sql-edge
     container_name: sqlserver_itu
     environment:
-      - SA_PASSWORD=Pass@word
+      - MSSQL_SA_PASSWORD=Pass@word
       - ACCEPT_EULA=Y
       - MSSQL_PID=Developer
     ports:

--- a/src/Sample/Sample.csproj
+++ b/src/Sample/Sample.csproj
@@ -6,6 +6,12 @@
     <RootNamespace>Sample</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Make it run on Apple Silicon -->
+    <DefineConstants>$(DefineConstants);RELEASE;TRACE</DefineConstants>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>true</Optimize>    
+    <!--  -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
SQL Server image has not been ported yet to ARM architecture, therefore I'm proposing Azure SQL Edge image instead. It should work for both ARM and x86.

Also, I got an error that prevented benchmarks to start:

**// Validating benchmarks:
Assembly Sample which defines benchmarks is non-optimized
Benchmark was built without optimization enabled (most probably a DEBUG configuration). Please, build it in RELEASE.
If you want to debug the benchmarks, please see https://benchmarkdotnet.org/articles/guides/troubleshooting.html#debugging-benchmarks.**

I added some lines following the recommendation from this post: [https://wojciechnagorski.com/2018/12/how-i-improved-the-yamldotnet-performance-by-370/](https://wojciechnagorski.com/2018/12/how-i-improved-the-yamldotnet-performance-by-370/) and it worked. As I'm not a .Net specialist, it is possible that there is a better solution.